### PR TITLE
#189 - Add reset mechanism to BusinessTime

### DIFF
--- a/src/main/java/org/salespointframework/time/BusinessTime.java
+++ b/src/main/java/org/salespointframework/time/BusinessTime.java
@@ -49,4 +49,9 @@ public interface BusinessTime {
 	 * @return
 	 */
 	Duration getOffset();
+	
+	/**
+	 * Undoes any forwarding. Afterwards any call to {@link #getTime()} will be equivalent to the system's time again.
+	 */
+	void reset();
 }

--- a/src/main/java/org/salespointframework/time/DefaultBusinessTime.java
+++ b/src/main/java/org/salespointframework/time/DefaultBusinessTime.java
@@ -57,4 +57,14 @@ class DefaultBusinessTime implements BusinessTime {
 	public Duration getOffset() {
 		return this.duration;
 	}
+	
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.salespointframework.time.BusinessTime#reset()
+	 */
+	@Override
+	public void reset() {
+		this.duration = Duration.ZERO;
+	}
 }


### PR DESCRIPTION
This is a proposal for a solution to the problem described in #189:

The `BusinessTime` class will be augmented by a `reset()` method which undoes any previous forwarding. This may be useful for testing and prevent test from failing due to a forward performed by another test.