### PR TITLE
Prefix columns of Quantity to avoid name clashes

### DIFF
--- a/src/main/java/org/salespointframework/quantity/Quantity.java
+++ b/src/main/java/org/salespointframework/quantity/Quantity.java
@@ -24,6 +24,7 @@ import lombok.Value;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
 import org.springframework.util.Assert;
@@ -42,13 +43,15 @@ public class Quantity {
 	private static final String INCOMPATIBLE = "Quantity %s is incompatible to quantity %s!";
 
 	/**
-	 * The amount of the Quantity.
+	 * The amount of the Quantity. Explicitely set a prefixed column name to avoid name conflicts.
 	 */
+	@Column(name = "quantity_amount")
 	private @NonNull final BigDecimal amount;
 
 	/**
-	 * The metric of the Quantity.
+	 * The metric of the Quantity. Explicitely set a prefixed column name to avoid name conflicts.
 	 */
+	@Column(name = "quantity_metric")
 	private @NonNull final Metric metric;
 
 	/**

--- a/src/test/java/org/salespointframework/quantity/QuantityIntegrationTests.java
+++ b/src/test/java/org/salespointframework/quantity/QuantityIntegrationTests.java
@@ -1,0 +1,24 @@
+package org.salespointframework.quantity;
+
+import org.junit.jupiter.api.Test;
+import org.salespointframework.AbstractIntegrationTests;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Integration tests for {@link Quantity}.
+ * 
+ * @author Martin Morgenstern
+ */
+class QuantityIntegrationTests extends AbstractIntegrationTests {
+	@Autowired
+	RepeatedNameEntityRepository repository;
+
+	/**
+	 * Verifies that an entity which embeds {@link Quantity} and repeats its
+	 * attribute names can be written to the database.
+	 */
+	@Test
+	void canRepeatAttributeName() {
+		repository.save(new RepeatedNameEntity());
+	}
+}

--- a/src/test/java/org/salespointframework/quantity/RepeatedNameEntity.java
+++ b/src/test/java/org/salespointframework/quantity/RepeatedNameEntity.java
@@ -1,0 +1,36 @@
+package org.salespointframework.quantity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * An entity that embeds {@link Quantity} and repeats its attribute names,
+ * {@code amount} and {@code metric}.
+ * 
+ * @author Martin Morgenstern
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class RepeatedNameEntity {
+	@Id
+	@GeneratedValue
+	private long id;
+
+	@Getter
+	@Setter
+	private int amount;
+
+	@Getter
+	@Setter
+	private String metric;
+
+	@Getter
+	@Setter
+	private Quantity quantity;
+}

--- a/src/test/java/org/salespointframework/quantity/RepeatedNameEntityRepository.java
+++ b/src/test/java/org/salespointframework/quantity/RepeatedNameEntityRepository.java
@@ -1,0 +1,11 @@
+package org.salespointframework.quantity;
+
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * Repository for {@link RepeatedNameEntity}.
+ * 
+ * @author Martin Morgenstern
+ */
+interface RepeatedNameEntityRepository extends CrudRepository<RepeatedNameEntity, Long> {
+}


### PR DESCRIPTION
This allows entities that use `Quantity` to define their own `metric` and `amount` attributes without producing any column name conflicts.