### PR TITLE
Add .factorypath to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ target/
 .settings/
 .project
 .classpath
+.factorypath
 .springBeans
 env.properties


### PR DESCRIPTION
This file is generated by m2e-apt (Eclipse/Maven integration for the JDT Annotation Processor Toolkit) and shouldn't be under version control.