### PR TITLE
Use stricter doclint settings and fix found Javadoc issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,6 +407,8 @@
 				<configuration>
 					<doclint>none</doclint>
 					<quiet>true</quiet>
+					<failOnError>true</failOnError>
+					<failOnWarnings>true</failOnWarnings>
 					<outputDirectory>${project.build.directory}/site${dev}/api</outputDirectory>
 					<sourcepath>target/generated-sources/delombok</sourcepath>
 					<links>

--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,14 @@
 			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
 		</dependency>
 
+		<!-- Fix "unknown enum constant javax.annotation.meta.When.MAYBE" warnings -->
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>3.0.2</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- Test -->
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,13 @@
 					<quiet>true</quiet>
 					<failOnError>true</failOnError>
 					<failOnWarnings>true</failOnWarnings>
+					<tags>
+						<!-- @soundtrack doctag can be used, but won't show up in generated docs -->
+						<tag>
+							<name>soundtrack</name>
+							<placement>X</placement>
+						</tag>
+					</tags>
 					<outputDirectory>${project.build.directory}/site${dev}/api</outputDirectory>
 					<sourcepath>target/generated-sources/delombok</sourcepath>
 					<links>

--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<doclint>none</doclint>
+					<doclint>all,-missing</doclint>
 					<quiet>true</quiet>
 					<failOnError>true</failOnError>
 					<failOnWarnings>true</failOnWarnings>

--- a/src/main/java/org/salespointframework/accountancy/package-info.java
+++ b/src/main/java/org/salespointframework/accountancy/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Accountancy subsystem with services for accounting and bookkeeping.
  *
- * @see https://en.wikipedia.org/wiki/Accounting
+ * @see <a href="https://en.wikipedia.org/wiki/Accounting">Accounting (Wikipedia)</a>
  */
 @org.springframework.lang.NonNullApi
 @org.springframework.modulith.ApplicationModule(displayName = "Salespoint :: Accountancy")

--- a/src/main/java/org/salespointframework/inventory/package-info.java
+++ b/src/main/java/org/salespointframework/inventory/package-info.java
@@ -1,8 +1,9 @@
 /**
  * The inventory subsystem.
  *
- * @see http://en.wikipedia.org/wiki/Inventory
+ * @see <a href="https://en.wikipedia.org/wiki/Inventory">Inventory (Wikipedia)</a>
  * @see org.salespointframework.inventory.UniqueInventory
+ * @see org.salespointframework.inventory.MultiInventory
  */
 @org.springframework.lang.NonNullApi
 @org.springframework.modulith.ApplicationModule(displayName = "Salespoint :: Inventory")

--- a/src/main/java/org/salespointframework/quantity/Quantity.java
+++ b/src/main/java/org/salespointframework/quantity/Quantity.java
@@ -61,7 +61,7 @@ public class Quantity {
 	private @NonNull Metric metric;
 
 	/**
-	 * Creates a new {@link Quantity} of the given amount. Defaults the metric to {@value Metric#UNIT}.
+	 * Creates a new {@link Quantity} of the given amount. Defaults the metric to {@link Metric#UNIT}.
 	 *
 	 * @param amount must not be {@literal null}.
 	 * @return
@@ -71,7 +71,7 @@ public class Quantity {
 	}
 
 	/**
-	 * Creates a new {@link Quantity} of the given amount. Defaults the metric to {@value Metric#UNIT}.
+	 * Creates a new {@link Quantity} of the given amount. Defaults the metric to {@link Metric#UNIT}.
 	 *
 	 * @param amount must not be {@literal null}.
 	 * @return

--- a/src/main/java/org/salespointframework/support/ConsoleWritingMailSender.java
+++ b/src/main/java/org/salespointframework/support/ConsoleWritingMailSender.java
@@ -45,11 +45,11 @@ import org.springframework.mail.SimpleMailMessage;
  * 
  * To use a real {@link MailSender} instead, include the {@code spring-boot-starter-mail} module in your Maven POM file
  * and follow the instructions in the
- * <a href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-email">reference
- * documentation</a>.
+ * <a href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#io.email">reference documentation</a>.
  * 
  * @author Oliver Gierke
- * @see http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-email
+ * @see <a href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#io.email">Sending Email (Spring
+ *      Boot Reference Docs)</a>
  * @see RecordingMailSender
  */
 public class ConsoleWritingMailSender implements MailSender {

--- a/src/main/java/org/salespointframework/useraccount/UserAccount.java
+++ b/src/main/java/org/salespointframework/useraccount/UserAccount.java
@@ -147,7 +147,7 @@ public class UserAccount extends AbstractAggregateRoot<UserAccountIdentifier> {
 	}
 
 	/**
-	 * @return A <code>Streamable/code> with all {@link Role}s of the user
+	 * @return A {@link Streamable} with all {@link Role}s of the user
 	 */
 	public Streamable<Role> getRoles() {
 		return Streamable.of(roles);


### PR DESCRIPTION
As proposed in #416 I have configured `maven-javadoc-plugin` to be stricter and also fail the build if there are warnings regarding the Javadoc, with the goal to automatically prevent obvious inconsistencies between code and Javadoc in the future.

@odrotbohm could you please have a look at the changes and say if you're okay with them? I've split the changes across smaller commits for easier review. They can of course be squashed into one commit for the merge into `main`.

Fixes: #416