### PR TITLE
Allow only unique AccountancyEntry when adding to Accountancy 

### DIFF
--- a/src/main/java/org/salespointframework/accountancy/PersistentAccountancy.java
+++ b/src/main/java/org/salespointframework/accountancy/PersistentAccountancy.java
@@ -62,6 +62,7 @@ class PersistentAccountancy implements Accountancy {
 	public final <T extends AccountancyEntry> T add(T accountancyEntry) {
 
 		Assert.notNull(accountancyEntry, "Accountancy entry must not be null!");
+		Assert.isTrue(!repository.existsById(accountancyEntry.getId()), "Accountancy entry must not exist in repository!");
 
 		if (!accountancyEntry.hasDate()) {
 			accountancyEntry.setDate(businessTime.getTime());

--- a/src/test/java/org/salespointframework/accountancy/AccountancyTests.java
+++ b/src/test/java/org/salespointframework/accountancy/AccountancyTests.java
@@ -15,6 +15,8 @@
  */
 package org.salespointframework.accountancy;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.time.LocalDateTime;
 
 import org.javamoney.moneta.Money;
@@ -82,5 +84,12 @@ class AccountancyTests {
 
 		System.out.println("All entries:");
 		accountancy.find(Interval.from(from).to(to)).forEach(System.out::println);
+	}
+
+	@Test
+	void addExistingEntry() {
+		var existingEntry = new AccountancyEntry(Money.of(1.00, Currencies.EURO));
+		accountancy.add(existingEntry);
+		assertThrows(IllegalArgumentException.class, () -> accountancy.add(existingEntry), "Adding the same AccountancyEntry more than once should result in IllegalArgumentException!");
 	}
 }


### PR DESCRIPTION
As proposed in #412 this change adds a check for whether the `AccountancyEntry` exists when calling `Accountancy.add(…)`. If the entry already exists an `IllegalArgumentException` is thrown.
Further a test case has been added to `AccountancyTests` which adds the same `AccountancyEntry` twice and excepts an `IllegalArgumentException` to be thrown.