### PR TITLE
Annote `Interval` with `@Embeddable`

### DIFF
--- a/src/main/java/org/salespointframework/time/Interval.java
+++ b/src/main/java/org/salespointframework/time/Interval.java
@@ -27,6 +27,8 @@ import java.time.temporal.TemporalAmount;
 
 import org.springframework.util.Assert;
 
+import jakarta.persistence.Embeddable;
+
 /**
  * Simple value object to represent time intervals. Note that whether the endpoints are included
  * or not can vary between the offered methods.
@@ -34,6 +36,7 @@ import org.springframework.util.Assert;
  * @author Oliver Drotbohm
  * @author Martin Morgenstern
  */
+@Embeddable
 @Value
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public final class Interval {

--- a/src/test/java/example/DummyEntity.java
+++ b/src/test/java/example/DummyEntity.java
@@ -15,6 +15,8 @@
  */
 package example;
 
+import org.salespointframework.time.Interval;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -26,4 +28,5 @@ import jakarta.persistence.Id;
 class DummyEntity {
 
 	@Id @GeneratedValue Long id;
+	Interval interval;
 }

--- a/src/test/java/org/salespointframework/time/IntervalIntegrationTests.java
+++ b/src/test/java/org/salespointframework/time/IntervalIntegrationTests.java
@@ -69,6 +69,6 @@ class IntervalIntegrationTests {
 	static class SomeEntity {
 
 		@Id @GeneratedValue Long id;
-		@Embedded Interval interval;
+		Interval interval;
 	}
 }


### PR DESCRIPTION
Execute steps mentioned in issue #370 by annotating `Interval` with `@Embeddable`, adding an `Interval` property to the `DummyEntity` and Removing the explicit  `@Embedded` annotation from the `IntervalIntegrationTests.SomeEntity`.